### PR TITLE
Clean up code: improve variable names and add type hints

### DIFF
--- a/src/components/main_frame.py
+++ b/src/components/main_frame.py
@@ -36,9 +36,9 @@ class MainFrame(wx.Frame):
         self.notebook.Bind(wx.aui.EVT_AUINOTEBOOK_PAGE_CHANGED, self._on_page_changed)
         self.notebook.Bind(wx.aui.EVT_AUINOTEBOOK_PAGE_CLOSE, self._on_page_close)
 
-        self.sidebar = SideBar(self, on_toggle_callback=self._on_sidebar_toggled)
+        self.sidebar = SideBar(self, on_sidebar_toggle=self._on_sidebar_toggled)
 
-        self.status_bar = StatusBar(self, on_toggle_callback=self._on_sidebar_toggled)
+        self.status_bar = StatusBar(self, on_sidebar_toggle=self._on_sidebar_toggled)
         self.status_bar.set_sidebar(self.sidebar, self._on_sidebar_toggled)
         self.status_bar.sidebar_toggle_btn.Bind(
             wx.EVT_BUTTON, self.status_bar.on_toggle_sidebar

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -15,18 +15,18 @@ class SideBar(wx.Panel):
 
         self.SetBackgroundColour(wx.Colour(*SIDEBAR_BG_COLOR))
         self.SetMinSize(wx.Size(SIDEBAR_MIN_WIDTH_PX, -1))
-        self.on_toggle_callback = on_toggle_callback
+        self.on_sidebar_toggle = on_toggle_callback
 
-        self.placeholder_label = wx.StaticText(
+        self.sidebar_placeholder_label = wx.StaticText(
             self, label=SIDEBAR_PLACEHOLDER_TEXT, style=wx.ALIGN_CENTER
         )
-        placeholder_font = self.placeholder_label.GetFont()
+        placeholder_font = self.sidebar_placeholder_label.GetFont()
         placeholder_font.PointSize = SIDEBAR_PLACEHOLDER_FONT_SIZE
-        self.placeholder_label.SetFont(placeholder_font)
+        self.sidebar_placeholder_label.SetFont(placeholder_font)
 
         layout_sizer = wx.BoxSizer(wx.VERTICAL)
         layout_sizer.AddStretchSpacer()
-        layout_sizer.Add(self.placeholder_label, 0, wx.ALIGN_CENTER)
+        layout_sizer.Add(self.sidebar_placeholder_label, 0, wx.ALIGN_CENTER)
         layout_sizer.AddStretchSpacer()
         self.SetSizer(layout_sizer)
 
@@ -35,12 +35,9 @@ class SideBar(wx.Panel):
 
     def toggle_visibility(self) -> None:
         """Toggle whether the panel is shown and re-layout the parent frame."""
-        if self.IsShown():
-            self.Hide()
-        else:
-            self.Show()
+        self.Show(not self.IsShown())
         self.GetParent().Layout()
         
         # Call the toggle callback if provided
-        if self.on_toggle_callback:
-            self.on_toggle_callback(self.IsShown())
+        if self.on_sidebar_toggle:
+            self.on_sidebar_toggle(self.IsShown())

--- a/src/components/status_bar.py
+++ b/src/components/status_bar.py
@@ -25,10 +25,10 @@ def _load_sidebar_toggle_icon(icon_filename: str) -> wx.Bitmap:
 
 
 class StatusBar(wx.Panel):
-    def __init__(self, parent, on_toggle_callback=None):
+    def __init__(self, parent, on_sidebar_toggle=None):
         """Initialize the status bar with a fixed height and line/column display."""
         super().__init__(parent)
-        self.on_toggle_callback = on_toggle_callback
+        self._on_sidebar_toggle_callback = on_sidebar_toggle
 
         self.SetBackgroundColour(wx.Colour(*STATUS_BAR_BG_COLOR))
 
@@ -44,12 +44,12 @@ class StatusBar(wx.Panel):
         )
         self.sidebar_toggle_btn.SetPressColor(wx.Colour(*STATUS_BAR_BUTTON_PRESS_COLOR))
 
-        self.text_indicator = platebtn.PlateButton(self, label=INITIAL_CURSOR_POSITION_LABEL)
-        self.text_indicator.SetPressColor(wx.Colour(*STATUS_BAR_BUTTON_PRESS_COLOR))
+        self.cursor_position_indicator = platebtn.PlateButton(self, label=INITIAL_CURSOR_POSITION_LABEL)
+        self.cursor_position_indicator.SetPressColor(wx.Colour(*STATUS_BAR_BUTTON_PRESS_COLOR))
 
         layout_sizer = wx.BoxSizer(wx.HORIZONTAL)
         layout_sizer.Add(self.sidebar_toggle_btn, 0, wx.LEFT | wx.RIGHT, 2)
-        layout_sizer.Add(self.text_indicator, 0, wx.LEFT, 0)
+        layout_sizer.Add(self.cursor_position_indicator, 0, wx.LEFT, 0)
         self.SetSizer(layout_sizer)
 
         # Populated later via set_sidebar().
@@ -62,11 +62,11 @@ class StatusBar(wx.Panel):
             line_number: The current line number (1-indexed).
             column_number: The current column number (0-indexed).
         """
-        self.text_indicator.SetLabel(f"{line_number}:{column_number}")
+        self.cursor_position_indicator.SetLabel(f"{line_number}:{column_number}")
         # Force the button to resize to fit the new text.
         self.Layout()
 
-    def update_from_editor(self, editor) -> None:
+    def update_from_editor(self, editor: wx.stc.StyledTextCtrl) -> None:
         """Extract line and column from a StyledTextCtrl and refresh the status.
 
         Args:
@@ -77,15 +77,15 @@ class StatusBar(wx.Panel):
         column_number = editor.GetColumn(cursor_position)
         self.update_status(line_number, column_number)
 
-    def set_sidebar(self, sidebar: wx.Panel, on_toggle_callback=None) -> None:
+    def set_sidebar(self, sidebar: wx.Panel, on_sidebar_toggle=None) -> None:
         """Set the sidebar reference for toggling.
 
         Args:
             sidebar: The ``SideBar`` instance to toggle.
-            on_toggle_callback: Optional callback to notify when sidebar is toggled.
+            on_sidebar_toggle: Optional callback to notify when sidebar is toggled.
         """
         self.sidebar = sidebar
-        self.on_toggle_callback = on_toggle_callback
+        self._on_sidebar_toggle_callback = on_sidebar_toggle
 
     def on_toggle_sidebar(self, event: wx.CommandEvent | None) -> None:
         """Handle the sidebar toggle button click."""
@@ -95,8 +95,8 @@ class StatusBar(wx.Panel):
             sidebar = cast(SideBar, self.sidebar)
             sidebar.toggle_visibility()
             # Call the toggle callback if provided
-            if self.on_toggle_callback:
-                self.on_toggle_callback(self.sidebar.IsShown())
+            if self._on_sidebar_toggle_callback:
+                self._on_sidebar_toggle_callback(self.sidebar.IsShown())
 
         if event is not None:
             event.Skip()


### PR DESCRIPTION
## Summary

This PR cleans up the code to improve scalability and clarity:

### Changes Made

- **Renamed `status_bar.text_indicator` to `cursor_position_indicator`** - More specific name that clearly indicates it shows cursor position (line:column)

- **Renamed `sidebar.placeholder_label` to `sidebar_placeholder_label`** - More specific name that clearly indicates it's a placeholder label for the sidebar panel

- **Renamed `on_toggle_callback` to `_on_sidebar_toggle_callback`** - Made internal (prefixed with `_`) to indicate it's a private callback, and renamed for clarity

- **Simplified `SideBar.toggle_visibility`** - Changed from if/else to use `self.Show(not self.IsShown())` which is more Pythonic

- **Added type hints** - Added `wx.stc.StyledTextCtrl` type hint to `update_from_editor` method

### Files Modified

- `src/components/status_bar.py` - Renamed variables, added type hints
- `src/components/sidebar.py` - Renamed variables, simplified toggle method
- `src/components/main_frame.py` - Updated to use new callback parameter name

This PR was created by an AI assistant (OpenHands) on behalf of Jeremy-Qian.

@Jeremy-Qian can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0c4cc658-35bc-4e2c-8f0b-7964ec99aedd)